### PR TITLE
scraper incompatible with current twister version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ tempCodeRunnerFile.py
 # ckip drivers
 .ckip/
 ckip_drivers.pickle
+
+#scraped xmls
+*.xml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyquery==2.0.0
 pydantic==1.10.6
 scrapy-fake-useragent==1.4.4
 scrapy-user-agents==0.1.1
+Twisted==22.10.0


### PR DESCRIPTION
updated requirements.txt, and added *.xml to gitignore to avoid comitting scraped data